### PR TITLE
remove type hints

### DIFF
--- a/lib/Auth/Process/BaseConditionalAuthProcInserter.php
+++ b/lib/Auth/Process/BaseConditionalAuthProcInserter.php
@@ -12,9 +12,9 @@ use SimpleSAML\Module\cirrusgeneral\Auth\AuthProcRuleInserter;
  */
 abstract class BaseConditionalAuthProcInserter extends ProcessingFilter
 {
-    protected array $authProcs;
+    protected $authProcs;
 
-    protected array $elseAuthProcs;
+    protected $elseAuthProcs;
 
 
     public function __construct(&$config, $reserved)

--- a/lib/Auth/Process/PhpConditionalAuthProcInserter.php
+++ b/lib/Auth/Process/PhpConditionalAuthProcInserter.php
@@ -11,7 +11,7 @@ use SimpleSAML\Module\cirrusgeneral\Auth\AuthProcRuleInserter;
  */
 class PhpConditionalAuthProcInserter extends BaseConditionalAuthProcInserter
 {
-    private string $condition;
+    private $condition;
 
 
     public function __construct(&$config, $reserved)


### PR DESCRIPTION
Remove type hints, which were introduced in PHP 7.4, so that code works on PHP 7.3